### PR TITLE
fix reversed names

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,14 +46,14 @@ class CreatePatient extends StatelessWidget {
               SmallActionButton(
                   title: 'Hapi: Create',
                   onPressed: () => _hapiCreate(
-                        _firstName.text,
                         _lastName.text,
+                        _firstName.text,
                       )),
               SmallActionButton(
                 title: 'Hapi: Search',
                 onPressed: () => _hapiSearch(
-                  _firstName.text,
                   _lastName.text,
+                  _firstName.text,
                 ),
               ),
             ],


### PR DESCRIPTION
Calls to _hapiCreate and _hapiSearch are ordered lastname, firstname but methods _hapiCreate and _hapiSearch are ordered firstname, lastname. In this version the are both lastname, firstname. 